### PR TITLE
Fix signature mismatch for public API calls

### DIFF
--- a/custom_components/ecoflow_cloud/api/public_api.py
+++ b/custom_components/ecoflow_cloud/api/public_api.py
@@ -87,6 +87,7 @@ class EcoflowPublicApiClient(EcoflowApiClient):
 
     async def call_api(self, endpoint: str, params: dict[str, str] = None) -> dict:
         async with aiohttp.ClientSession() as session:
+            self.timestamp = str(int(time.time() * 1000))  # Refresh timestamp just before signing
             params_str = ""
             if params is not None:
                 params_str = self.__sort_and_concat_params(params)


### PR DESCRIPTION
This pull request updates the EcoflowPublicApiClient to refresh the `timestamp` for each request, which prevents stale signature errors such as "signature is wrong". Tested against DELTA device integration with Home Assistant. Resolves quota polling failures on startup.