### PR TITLE
Add DELTA Pro Ultra and Smart Home Panel 2 public API device support

### DIFF
--- a/custom_components/ecoflow_cloud/devices/public/delta_pro_ultra.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta_pro_ultra.py
@@ -1,0 +1,120 @@
+from custom_components.ecoflow_cloud.api import EcoflowApiClient
+from custom_components.ecoflow_cloud.devices import const, BaseDevice
+from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, \
+    BaseSelectEntity
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity, WattsSensorEntity, RemainSensorEntity,
+    TempSensorEntity, CyclesSensorEntity, OutWattsSensorEntity,
+    InWattsSensorEntity, VoltSensorEntity, AmpSensorEntity,
+    CapacitySensorEntity, QuotaStatusSensorEntity,
+)
+
+
+class DeltaProUltra(BaseDevice):
+    """EcoFlow DELTA Pro Ultra – public API device.
+
+    Key prefixes in the quota response:
+      hs_yj751_pd_appshow_addr.*   – display/summary values (SOC, watts in/out, etc.)
+      hs_yj751_pd_backend_addr.*   – inverter/BMS backend values (volts, temps, etc.)
+      hs_yj751_bms_slave_addr.N.*  – per-pack BMS data (N = 1 or 2)
+      hs_yj751_pd_app_set_info_addr.* – user-configurable settings
+    """
+
+    def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
+        return [
+            # ── Main battery level ──────────────────────────────────────────────
+            LevelSensorEntity(client, self, "hs_yj751_pd_appshow_addr.soc", const.MAIN_BATTERY_LEVEL)
+            .attr("hs_yj751_bms_slave_addr.1.remainCap", const.ATTR_REMAIN_CAPACITY, 0)
+            .attr("hs_yj751_bms_slave_addr.1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("hs_yj751_bms_slave_addr.1.designCap", const.ATTR_DESIGN_CAPACITY, 0),
+
+            # ── Total power (in / out) ──────────────────────────────────────────
+            WattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.wattsInSum", const.TOTAL_IN_POWER),
+            WattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.wattsOutSum", const.TOTAL_OUT_POWER),
+
+            # ── Discharge remaining time ────────────────────────────────────────
+            RemainSensorEntity(client, self, "hs_yj751_pd_appshow_addr.remainTime",
+                               const.DISCHARGE_REMAINING_TIME),
+
+            # ── AC ports ────────────────────────────────────────────────────────
+            # 5.8 kW AC input port
+            InWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.inAc5p8Pwr", const.AC_IN_POWER),
+            # AC output – total and per-leg
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outAcTtPwr", const.AC_OUT_POWER),
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outAcL11Pwr", "AC Out L1-1 Power"),
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outAcL12Pwr", "AC Out L1-2 Power"),
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outAcL21Pwr", "AC Out L2-1 Power"),
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outAcL22Pwr", "AC Out L2-2 Power"),
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outAc5p8Pwr", "5.8kW Port Out Power"),
+
+            # ── Solar (MPPT) ────────────────────────────────────────────────────
+            InWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.inHvMpptPwr", "Solar HV In Power"),
+            InWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.inLvMpptPwr", "Solar LV In Power"),
+
+            # ── USB / Type-C ────────────────────────────────────────────────────
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outTypec1Pwr",
+                                 const.TYPEC_1_OUT_POWER),
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outTypec2Pwr",
+                                 const.TYPEC_2_OUT_POWER),
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outUsb1Pwr", const.USB_1_OUT_POWER),
+            OutWattsSensorEntity(client, self, "hs_yj751_pd_appshow_addr.outUsb2Pwr", const.USB_2_OUT_POWER),
+
+            # ── BMS backend ────────────────────────────────────────────────────
+            WattsSensorEntity(client, self, "hs_yj751_pd_backend_addr.bmsOutputWatts", "BMS Output Power"),
+            WattsSensorEntity(client, self, "hs_yj751_pd_backend_addr.bmsInputWatts", "BMS Input Power"),
+            VoltSensorEntity(client, self, "hs_yj751_pd_backend_addr.batVol", const.BATTERY_VOLT, False),
+
+            # ── Temperatures ────────────────────────────────────────────────────
+            TempSensorEntity(client, self, "hs_yj751_pd_backend_addr.pcsAcTemp", "PCS Temperature"),
+            TempSensorEntity(client, self, "hs_yj751_pd_backend_addr.pdTemp", "PD Temperature"),
+
+            # ── Battery Pack 1 (hs_yj751_bms_slave_addr.1.*) ───────────────────
+            LevelSensorEntity(client, self, "hs_yj751_bms_slave_addr.1.soc",
+                              const.SLAVE_N_BATTERY_LEVEL % 1, False, True)
+            .attr("hs_yj751_bms_slave_addr.1.remainCap", const.ATTR_REMAIN_CAPACITY, 0)
+            .attr("hs_yj751_bms_slave_addr.1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("hs_yj751_bms_slave_addr.1.designCap", const.ATTR_DESIGN_CAPACITY, 0),
+            CapacitySensorEntity(client, self, "hs_yj751_bms_slave_addr.1.remainCap",
+                                 const.SLAVE_N_REMAIN_CAPACITY % 1, False),
+            CapacitySensorEntity(client, self, "hs_yj751_bms_slave_addr.1.fullCap",
+                                 const.SLAVE_N_FULL_CAPACITY % 1, False),
+            CapacitySensorEntity(client, self, "hs_yj751_bms_slave_addr.1.designCap",
+                                 const.SLAVE_N_DESIGN_CAPACITY % 1, False),
+            TempSensorEntity(client, self, "hs_yj751_bms_slave_addr.1.temp",
+                             const.SLAVE_N_BATTERY_TEMP % 1, False, True),
+            CyclesSensorEntity(client, self, "hs_yj751_bms_slave_addr.1.cycles",
+                               const.SLAVE_N_CYCLES % 1, False),
+            AmpSensorEntity(client, self, "hs_yj751_bms_slave_addr.1.amp",
+                            const.SLAVE_N_BATTERY_CURRENT % 1, False),
+
+            # ── Battery Pack 2 (hs_yj751_bms_slave_addr.2.*) ───────────────────
+            LevelSensorEntity(client, self, "hs_yj751_bms_slave_addr.2.soc",
+                              const.SLAVE_N_BATTERY_LEVEL % 2, False, True)
+            .attr("hs_yj751_bms_slave_addr.2.remainCap", const.ATTR_REMAIN_CAPACITY, 0)
+            .attr("hs_yj751_bms_slave_addr.2.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("hs_yj751_bms_slave_addr.2.designCap", const.ATTR_DESIGN_CAPACITY, 0),
+            CapacitySensorEntity(client, self, "hs_yj751_bms_slave_addr.2.remainCap",
+                                 const.SLAVE_N_REMAIN_CAPACITY % 2, False),
+            CapacitySensorEntity(client, self, "hs_yj751_bms_slave_addr.2.fullCap",
+                                 const.SLAVE_N_FULL_CAPACITY % 2, False),
+            CapacitySensorEntity(client, self, "hs_yj751_bms_slave_addr.2.designCap",
+                                 const.SLAVE_N_DESIGN_CAPACITY % 2, False),
+            TempSensorEntity(client, self, "hs_yj751_bms_slave_addr.2.temp",
+                             const.SLAVE_N_BATTERY_TEMP % 2, False, True),
+            CyclesSensorEntity(client, self, "hs_yj751_bms_slave_addr.2.cycles",
+                               const.SLAVE_N_CYCLES % 2, False),
+            AmpSensorEntity(client, self, "hs_yj751_bms_slave_addr.2.amp",
+                            const.SLAVE_N_BATTERY_CURRENT % 2, False),
+
+            QuotaStatusSensorEntity(client, self),
+        ]
+
+    def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
+        # Write command formats for DPU public API not yet known.
+        return []
+
+    def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
+        return []
+
+    def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
+        return []

--- a/custom_components/ecoflow_cloud/devices/public/smart_home_panel_2.py
+++ b/custom_components/ecoflow_cloud/devices/public/smart_home_panel_2.py
@@ -7,7 +7,7 @@ from custom_components.ecoflow_cloud.devices import const, BaseDevice
 from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, \
     BaseSelectEntity
 from custom_components.ecoflow_cloud.sensor import (
-    LevelSensorEntity, WattsSensorEntity, RemainSensorEntity,
+    LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, InWattsSensorEntity,
     VoltSensorEntity, FrequencySensorEntity, MiscSensorEntity,
     QuotaStatusSensorEntity,
 )
@@ -83,6 +83,9 @@ class SmartHomePanel2(BaseDevice):
             WattsSensorEntity(client, self,
                               "pd303_mc.backupIncreInfo.Energy3Info.outputPower",
                               "Backup Unit Output Power", False),
+            InWattsSensorEntity(client, self,
+                              "pd303_mc.backupIncreInfo.Energy3Info.lcdInputWatts",
+                              "Backup Unit Charge Power", False),
 
             # ── Backup channel watts (3-element array, 0-indexed) ─────────────────
             CircuitWattsSensorEntity(client, self, "wattInfo.chWatt", 0,

--- a/custom_components/ecoflow_cloud/devices/public/smart_home_panel_2.py
+++ b/custom_components/ecoflow_cloud/devices/public/smart_home_panel_2.py
@@ -1,0 +1,126 @@
+from typing import Any
+
+import jsonpath_ng.ext as jp
+
+from custom_components.ecoflow_cloud.api import EcoflowApiClient
+from custom_components.ecoflow_cloud.devices import const, BaseDevice
+from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, \
+    BaseSelectEntity
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity, WattsSensorEntity, RemainSensorEntity,
+    VoltSensorEntity, FrequencySensorEntity, MiscSensorEntity,
+    QuotaStatusSensorEntity,
+)
+
+
+class CircuitWattsSensorEntity(WattsSensorEntity):
+    """Reads one element from an array-valued quota key.
+
+    The EcoFlow Smart Home Panel 2 reports per-circuit watts as a single
+    JSON array key (e.g. ``loadInfo.hall1Watt`` = [w1, w2, ..., w12]).
+    This entity wraps that array key and exposes a single indexed element,
+    generating a unique entity ID from ``<array_key>.<index>``.
+    """
+
+    def __init__(self, client: EcoflowApiClient, device: BaseDevice,
+                 array_key: str, index: int, title: str, enabled: bool = True):
+        # Parent stores <array_key>.<index> as the mqtt_key → unique entity ID
+        super().__init__(client, device, f"{array_key}.{index}", title, enabled)
+        # Override lookup to fetch the whole array under the real flat key
+        self._mqtt_key_adopted = "'" + array_key + "'"
+        self._mqtt_key_expr = jp.parse(self._mqtt_key_adopted)
+        self._index = index
+
+    def _update_value(self, val: Any) -> bool:
+        if isinstance(val, list) and len(val) > self._index:
+            return super()._update_value(val[self._index])
+        return False
+
+
+class SmartHomePanel2(BaseDevice):
+    """EcoFlow Smart Home Panel 2 – public API device.
+
+    Key structure in the quota response:
+      wattInfo.*                              – whole-panel power summary
+      loadInfo.hall1Watt                      – array[12] of per-circuit watts
+      pd303_mc.masterIncreInfo.*              – grid voltage / relay state
+      pd303_mc.backupIncreInfo.*              – backup battery & channel info
+      pd303_mc.loadIncreInfo.hall1IncreInfo.* – per-circuit names, limits, state
+      backupInfo.*                            – backup timing
+    """
+
+    def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
+        return [
+            # ── Whole-panel power ────────────────────────────────────────────────
+            WattsSensorEntity(client, self, "wattInfo.gridWatt", "Grid Power"),
+            WattsSensorEntity(client, self, "wattInfo.allHallWatt", "Total Load Power"),
+
+            # ── Per-circuit watts (12-element array, 0-indexed) ──────────────────
+            # Indices correspond to circuits 1-12 as labelled in the EcoFlow app.
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 0, "Circuit 1 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 1, "Circuit 2 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 2, "Circuit 3 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 3, "Circuit 4 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 4, "Circuit 5 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 5, "Circuit 6 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 6, "Circuit 7 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 7, "Circuit 8 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 8, "Circuit 9 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 9, "Circuit 10 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 10, "Circuit 11 Power"),
+            CircuitWattsSensorEntity(client, self, "loadInfo.hall1Watt", 11, "Circuit 12 Power"),
+
+            # ── Backup battery (connected unit, e.g. DELTA Pro Ultra) ─────────────
+            LevelSensorEntity(client, self, "pd303_mc.backupIncreInfo.backupBatPer",
+                              "Backup Battery Level")
+            .attr("pd303_mc.backupIncreInfo.backupFullCap", "Full Capacity (Wh)", 0)
+            .attr("pd303_mc.backupIncreInfo.backupDischargeRmainBatCap", "Remain Capacity (Wh)", 0),
+
+            # Battery percentage as reported directly by the connected backup device
+            LevelSensorEntity(client, self,
+                              "pd303_mc.backupIncreInfo.Energy3Info.batteryPercentage",
+                              "Backup Unit Battery Level", False),
+            WattsSensorEntity(client, self,
+                              "pd303_mc.backupIncreInfo.Energy3Info.outputPower",
+                              "Backup Unit Output Power", False),
+
+            # ── Backup channel watts (3-element array, 0-indexed) ─────────────────
+            CircuitWattsSensorEntity(client, self, "wattInfo.chWatt", 0,
+                                     "Backup Channel 1 Power", False),
+            CircuitWattsSensorEntity(client, self, "wattInfo.chWatt", 1,
+                                     "Backup Channel 2 Power", False),
+            CircuitWattsSensorEntity(client, self, "wattInfo.chWatt", 2,
+                                     "Backup Channel 3 Power", False),
+
+            # ── Grid ──────────────────────────────────────────────────────────────
+            VoltSensorEntity(client, self, "pd303_mc.masterIncreInfo.gridVol", "Grid Voltage"),
+            FrequencySensorEntity(client, self, "pd303_mc.gridFreq", "Grid Frequency"),
+
+            # ── Backup timing ────────────────────────────────────────────────────
+            RemainSensorEntity(client, self, "backupInfo.backupChargeTime",
+                               const.CHARGE_REMAINING_TIME),
+            RemainSensorEntity(client, self, "backupInfo.backupDischargeTime",
+                               const.DISCHARGE_REMAINING_TIME),
+
+            # ── Operating state & config ──────────────────────────────────────────
+            LevelSensorEntity(client, self, "pd303_mc.backupReserveSoc",
+                              "Backup Reserve Level", False),
+            WattsSensorEntity(client, self, "pd303_mc.chargeWattPower", "Charge Power", False),
+            MiscSensorEntity(client, self, "pd303_mc.powerSta", "Power Status", False),
+            MiscSensorEntity(client, self, "pd303_mc.backupIncreInfo.ch3Info.ctrlSta",
+                             "Backup Channel 3 Status", False),
+            MiscSensorEntity(client, self, "pd303_mc.sysCurRunningState",
+                             "System Running State", False),
+
+            QuotaStatusSensorEntity(client, self),
+        ]
+
+    def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
+        # Write command formats for Smart Home Panel 2 public API not yet known.
+        return []
+
+    def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
+        return []
+
+    def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
+        return []

--- a/custom_components/ecoflow_cloud/devices/registry.py
+++ b/custom_components/ecoflow_cloud/devices/registry.py
@@ -24,6 +24,8 @@ from .public import (delta_pro as public_delta_pro,
                      smart_plug as public_smart_plug,
                      powerstream as public_powerstream,
                      wave3 as public_wave3,
+                     delta_pro_ultra as public_delta_pro_ultra,
+                     smart_home_panel_2 as public_smart_home_panel_2,
                      )
 from ..devices import BaseDevice, DiagnosticDevice
 
@@ -56,5 +58,7 @@ device_by_product: OrderedDict[str, Type[BaseDevice]] = OrderedDict[str, Type[Ba
     "Smart Plug": public_smart_plug.SmartPlug,
     "PowerStream": public_powerstream.PowerStream,
     "Wave 3": public_wave3.Wave3,
+    "DELTA Pro Ultra": public_delta_pro_ultra.DeltaProUltra,
+    "Smart Home Panel 2": public_smart_home_panel_2.SmartHomePanel2,
     "Diagnostic": DiagnosticDevice
 })


### PR DESCRIPTION
## Summary

Adds public API device support for two EcoFlow products not currently in the integration:

- **DELTA Pro Ultra** (`productName: "DELTA Pro Ultra"`)
- **Smart Home Panel 2** (`productName: "Smart Home Panel 2"`)

Both devices were verified against live quota API responses from real hardware.

---

## DELTA Pro Ultra (`delta_pro_ultra.py`)

Sensors cover the full set of useful read-only values from the device's three quota key prefixes:

| Group | Key prefix | Sensors |
|---|---|---|
| Display/summary | `hs_yj751_pd_appshow_addr.*` | Combined SOC, total in/out watts, remaining time, AC out per-leg, solar HV/LV, USB/Type-C ports |
| Backend | `hs_yj751_pd_backend_addr.*` | BMS in/out watts, battery voltage, PCS & PD temperatures |
| Per-pack BMS | `hs_yj751_bms_slave_addr.N.*` | SOC, capacity (remain/full/design), temp, cycles, current for pack 1 and pack 2 |

The device has 2 × 6 kWh battery packs (SNs `Y712ZABA4H2D0045` and `Y712ZABA4H1A0283`).

---

## Smart Home Panel 2 (`smart_home_panel_2.py`)

Key challenge: the per-circuit wattage data is delivered as a **12-element array** under the flat key `loadInfo.hall1Watt`, rather than individual scalar keys. The existing `EcoFlowDictEntity` infrastructure resolves flat keys via single-quoted jsonpath expressions and cannot directly index into arrays.

This PR introduces `CircuitWattsSensorEntity` — a lightweight `WattsSensorEntity` subclass that:
1. Accepts `(array_key, index)` and generates a unique entity ID from `array_key.index`
2. Overrides `_mqtt_key_adopted` / `_mqtt_key_expr` to look up the raw array
3. Overrides `_update_value` to extract and forward the element at `index`

The same helper is reused for the 3-element `wattInfo.chWatt` (backup channel watts).

Sensors provided:
- Grid power, total load power
- 12 individual circuit watts (Circuits 1–12)
- Backup battery level + capacity attributes (from connected DELTA Pro Ultra)
- Backup unit battery level & output power
- 3 backup channel watts
- Grid voltage & frequency
- Backup charge / discharge remaining time
- Backup reserve level, charge power, power status, backup channel status

---

## Notes

- Both devices return **`numbers()`, `switches()`, `selects()` as empty lists** — the write-command formats for the public MQTT API of these products are not yet reverse-engineered. Happy to add them once the format is known.
- `registry.py` registers both by their exact `productName` strings as returned by the `/device/list` endpoint.
- No changes to existing devices or shared infrastructure.

Co-Authored-By: Oz <oz-agent@warp.dev>